### PR TITLE
(WIP) feat: Use a new config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,74 +48,74 @@ GLOBAL OPTIONS:
 ```bash
 # create a new base
 
-$ kubekutr -c config.yml scaffold -o myapp
+$ kubekutr -c config.yml scaffold -o myproject
 
 # `myapp` is created with the GitOps structure
-myapp
+myproject
 `-- base
-    |-- deployments
-    |   `-- app.yml
-    |-- ingresses
-    |   `-- app.yml
-    |-- services
-    |   `-- app.yml
-    `-- statefulsets
-        `-- app.yml
+    |-- app
+    |   |-- app-deployment.yml
+    |   |-- app-ingress.yml
+    |   |-- app-service.yml
+    |-- second-app
+        |-- db-statefulset.yml
 ```
 
 ## Configuration
 
--   **deployments**
+- **workloads**
+    -   **name**: Name of the workload. A workload represents the complete set of resources required to deploy an application
+    -   **deployments**
 
-    -   **name**: Name of the deployment
-    -   **replicas**: Represents the number of replicas for a `Pod`
-    -   **labels**:
-        - **name**: Represent the key value pair as a string. For eg: `"app.kubernetes.io/tier: cache"`
-    -   **containers**: List of containers in a Pod
-        - **name**: Unique name for a container
-        - **image**: Docker image name
-        - **portInt**: Number of port to expose from Container
-        - **portName**: Human friendly name for a port
-        - **command**: Entrypoint array
-        - **args**: Arguments to the entrypoint
-        - **envVars**: List of environment variables to set in the container
-            - **name**: Name of environment variable
-            - **value**: Value of environment variable
-        - **volumeMounts**: Pod volumes to mount into the container's filesystem
-            - **name**: Name of Volume
-            - **mountPath**: Path within the container at which the volume should be mounted
-            - **subPath**: Path within the volume from which the container's volume should be mounted.
-    -   **volumes**: List of volumes defined for a deployment
-            - **name**: Name of Volume
+        -   **name**: Name of the deployment
+        -   **replicas**: Represents the number of replicas for a `Pod`
+        -   **labels**:
+            - **name**: Represent the key value pair as a string. For eg: `"app.kubernetes.io/tier: cache"`
+        -   **containers**: List of containers in a Pod
+            - **name**: Unique name for a container
+            - **image**: Docker image name
+            - **portInt**: Number of port to expose from Container
+            - **portName**: Human friendly name for a port
+            - **command**: Entrypoint array
+            - **args**: Arguments to the entrypoint
+            - **envVars**: List of environment variables to set in the container
+                - **name**: Name of environment variable
+                - **value**: Value of environment variable
+            - **volumeMounts**: Pod volumes to mount into the container's filesystem
+                - **name**: Name of Volume
+                - **mountPath**: Path within the container at which the volume should be mounted
+                - **subPath**: Path within the volume from which the container's volume should be mounted.
+        -   **volumes**: List of volumes defined for a deployment
+                - **name**: Name of Volume
 
--   **statefulsets**
+    -   **statefulsets**
 
-    -   **name**: Name of the statefulset
-    -   **serviceName**: serviceName is the name of the service that governs this StatefulSet
-    -   **labels**: (reference above)
-    -   **containers**: (reference above)
-    -   **volumes**:(reference above)
+        -   **name**: Name of the statefulset
+        -   **serviceName**: serviceName is the name of the service that governs this StatefulSet
+        -   **labels**: (reference above)
+        -   **containers**: (reference above)
+        -   **volumes**:(reference above)
 
--   **services**
+    -   **services**
 
-    -   **name**: Name of service
-    -   **type**: Type of service. Can be one of `ClusterIP`, `NodePort`, `LoadBalancer`
-    -   **port**: The port that will be exposed by this service
-    -   **targetPort**: Number or name of the port to access on the pods targeted by the service
-    -   **labels**: (reference above)
-    -   **selectors**:
-        - **name**:  Route service traffic to pods with label keys and values matching this selector
+        -   **name**: Name of service
+        -   **type**: Type of service. Can be one of `ClusterIP`, `NodePort`, `LoadBalancer`
+        -   **port**: The port that will be exposed by this service
+        -   **targetPort**: Number or name of the port to access on the pods targeted by the service
+        -   **labels**: (reference above)
+        -   **selectors**:
+            - **name**:  Route service traffic to pods with label keys and values matching this selector
 
--   **ingresses**
+    -   **ingresses**
 
-    -   **name**: Name of ingress
-    -   **ingressPaths**
-        -   **path**: Path which map requests to backends
-        -   **service**: Specifies the name of the referenced service
-        -   **port**: Specifies the port of the referenced service
-    -   **labels**: (reference above)
-    -   **annotations**:
-        - **name**:  Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata
+        -   **name**: Name of ingress
+        -   **ingressPaths**
+            -   **path**: Path which map requests to backends
+            -   **service**: Specifies the name of the referenced service
+            -   **port**: Specifies the port of the referenced service
+        -   **labels**: (reference above)
+        -   **annotations**:
+            - **name**:  Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata
 
 ## Contributing
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,3 +31,7 @@
 - [ ] More resources and specs
 
 - [ ] Generate `kustomization.yaml` too
+
+- [ ] Write tests
+
+- [ ] Support application based workload config

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,8 @@
 
 - [x] Blogpost on a working example
 
+- [x] Support application based workload config
+
 - [ ] Add output to stdout
 
 - [ ] RBAC resources manifests
@@ -33,5 +35,3 @@
 - [ ] Generate `kustomization.yaml` too
 
 - [ ] Write tests
-
-- [ ] Support application based workload config

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -1,8 +1,0 @@
-package cmd
-
-import "zerodha.tech/kubekutr/models"
-
-var (
-	// parentPaths = []string{BaseDir}
-	subPaths = []string{models.DeploymentsDir, models.StatefulsetsDir, models.ServicesDir, models.IngressesDir}
-)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,9 +6,9 @@ import (
 	"zerodha.tech/kubekutr/utils"
 )
 
-func prepareResources(resources []models.Resource, projectDir string, fs stuffbin.FileSystem) error {
+func prepareResources(resources []models.Resource, projectDir string, workload string, fs stuffbin.FileSystem) error {
 	for _, r := range resources {
-		err := utils.CreateResource(r, projectDir, fs)
+		err := utils.CreateResource(r, projectDir, workload, fs)
 		if err != nil {
 			return err
 		}

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -1,63 +1,63 @@
-deployments:
+workloads:
   - name: app
-    replicas: 3
-    labels:
-      - name: 'service: app'
-      - name: 'tier: frontend'
-    containers:
+    deployments:
       - name: app
-        image: 'myapp:latest'
-        envSecret: myapp
-        portInt: 3000
-        portName: app-port
-        command: '["./myapp"]'
-        args: '["--config", "--hello"]'
-        envVars:
-          - name: hello
-            value: iamsecret
-        volumeMounts:
+        replicas: 3
+        labels:
+          - name: 'service: app'
+          - name: 'tier: frontend'
+        containers:
+          - name: app
+            image: 'myapp:latest'
+            envSecret: myapp
+            portInt: 3000
+            portName: app-port
+            command: '["./myapp"]'
+            args: '["--config", "--hello"]'
+            envVars:
+              - name: hello
+                value: iamsecret
+            volumeMounts:
+              - name: config-dir
+                mountPath: /etc/config
+                subPath: config.toml
+        volumes:
           - name: config-dir
-            mountPath: /etc/config
-            subPath: config.toml
-    volumes:
-      - name: config-dir
-
-services:
-  - name: app
-    type: NodePort
-    port: 7000
-    targetPort: 8000
-    labels:
-      - name: 'service: app'
-    selectors:
-      - name: 'tier: frontend'
-
-ingresses:
-  - name: app
-    annotations:
-      - name: 'alb.ingress.kubernetes.io/healthy-threshold-count: "2"'
-    ingressPaths:
-      - path: /503
-        service: app
-        port: use-annotation
-
-statefulsets:
-  - name: db
-    serviceName: db-headless
-    labels:
-      - name: 'service: postgres'
-      - name: 'tier: db'
-    containers:
-      - name: postgres
-        image: 'postgres:latest'
-        envSecret: postgres
-        portInt: 5432
-        portName: db-port
-        envVars:
-          - name: POSTGRES_DB
-            value: sample
-        volumeMounts:
+    services:
+      - name: app
+        type: NodePort
+        port: 7000
+        targetPort: 8000
+        labels:
+          - name: 'service: app'
+        selectors:
+          - name: 'tier: frontend'
+    ingresses:
+      - name: app
+        annotations:
+          - name: 'alb.ingress.kubernetes.io/healthy-threshold-count: "2"'
+        ingressPaths:
+          - path: /503
+            service: app
+            port: use-annotation
+  - name: storeme-app
+    statefulsets:
+      - name: db
+        serviceName: db-headless
+        labels:
+          - name: 'service: postgres'
+          - name: 'tier: db'
+        containers:
+          - name: postgres
+            image: 'postgres:latest'
+            envSecret: postgres
+            portInt: 5432
+            portName: db-port
+            envVars:
+              - name: POSTGRES_DB
+                value: sample
+            volumeMounts:
+              - name: db-dir
+                mount: /var/lib/postgres
+        volumes:
           - name: db-dir
-            mount: /var/lib/postgres
-    volumes:
-      - name: db-dir

--- a/models/const.go
+++ b/models/const.go
@@ -3,12 +3,12 @@ package models
 import "fmt"
 
 const (
-	BaseDir         = "base"
-	DeploymentsDir  = "deployments"
-	ServicesDir     = "services"
-	IngressesDir    = "ingresses"
-	StatefulsetsDir = "statefulsets"
-	TemplatesDir    = "templates"
+	BaseDir      = "base"
+	Deployments  = "deployment"
+	Services     = "service"
+	Ingresses    = "ingress"
+	Statefulsets = "statefulset"
+	TemplatesDir = "templates"
 )
 
 var (

--- a/models/deployment.go
+++ b/models/deployment.go
@@ -11,6 +11,6 @@ func (dep Deployment) GetMetaData() ResourceMeta {
 			"Labels":     dep.Labels,
 			"Volumes":    dep.Volumes,
 		},
-		ManifestPath: DeploymentsDir,
+		Type: Deployments,
 	}
 }

--- a/models/ingress.go
+++ b/models/ingress.go
@@ -11,6 +11,6 @@ func (ing Ingress) GetMetaData() ResourceMeta {
 			"Annotations": ing.Annotations,
 			"Labels":      ing.Labels,
 		},
-		ManifestPath: IngressesDir,
+		Type: Ingresses,
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -2,6 +2,12 @@ package models
 
 // Config represents the structure to hold configuration loaded from an external data source.
 type Config struct {
+	Workloads []Workload `koanf:"workloads"`
+}
+
+// Workload represents the structure to represent all configs and resources to deploy an application.
+type Workload struct {
+	Name         string        `koanf:"name"`
 	Deployments  []Deployment  `koanf:"deployments"`
 	Services     []Service     `koanf:"services"`
 	Ingresses    []Ingress     `koanf:"ingresses"`
@@ -66,19 +72,6 @@ type IngressPath struct {
 	Port    string `koanf:"port"`
 }
 
-// Resource is a set of common actions performed on Resource Types.
-type Resource interface {
-	GetMetaData() ResourceMeta
-}
-
-// ResourceMeta contains metadata for preparing resource manifests.
-type ResourceMeta struct {
-	Name         string
-	Config       map[string]interface{}
-	TemplatePath string
-	ManifestPath string
-}
-
 // Annotation represents the name of annotation value.
 type Annotation struct {
 	Name string `koanf:"name"`
@@ -111,4 +104,17 @@ type VolumeMount struct {
 // ConfigMap as the source.
 type Volume struct {
 	Name string `koanf:"name"`
+}
+
+// Resource is a set of common actions performed on Resource Types.
+type Resource interface {
+	GetMetaData() ResourceMeta
+}
+
+// ResourceMeta contains metadata for preparing resource manifests.
+type ResourceMeta struct {
+	Name         string
+	Config       map[string]interface{}
+	TemplatePath string
+	Type         string
 }

--- a/models/service.go
+++ b/models/service.go
@@ -12,6 +12,6 @@ func (svc Service) GetMetaData() ResourceMeta {
 			"Labels":     svc.Labels,
 			"Selectors":  svc.Selectors,
 		},
-		ManifestPath: ServicesDir,
+		Type: Services,
 	}
 }

--- a/models/statefulset.go
+++ b/models/statefulset.go
@@ -11,6 +11,6 @@ func (ss StatefulSet) GetMetaData() ResourceMeta {
 			"Containers":  ss.Containers,
 			"Volumes":     ss.Volumes,
 		},
-		ManifestPath: StatefulsetsDir,
+		Type: Statefulsets,
 	}
 }

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -16,10 +16,8 @@ func GetRootDir(dest string) string {
 // CreateGitopsDirectory creates an opinionated directory structure to organize
 // resource manifests efficiently. The directory is ideally to be used with Kustomize
 // as a "base".
-func CreateGitopsDirectory(subPaths []string, parentDir string) {
-	for _, p := range subPaths {
-		os.MkdirAll(filepath.Join(parentDir, "base", p), os.ModePerm)
-	}
+func CreateGitopsDirectory(parentDir string, workload string) {
+	os.MkdirAll(filepath.Join(parentDir, "base", workload), os.ModePerm)
 }
 
 // LookupGitopsDirectory checks if a directory with the same path already exists or not.

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"text/template"
 
 	"github.com/knadh/stuffbin"
@@ -39,7 +38,7 @@ func parse(src string, dest string, config map[string]interface{}, fs stuffbin.F
 
 func saveResource(template string, name string, dest string, config map[string]interface{}, fs stuffbin.FileSystem) error {
 	// parse template file and output yaml
-	err := parse(template, filepath.Join(dest, fmt.Sprintf("%s.yml", name)), config, fs)
+	err := parse(template, dest, config, fs)
 	if err != nil {
 		return err
 	}

--- a/utils/resources.go
+++ b/utils/resources.go
@@ -1,19 +1,21 @@
 package utils
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/knadh/stuffbin"
 	"zerodha.tech/kubekutr/models"
 )
 
-// CreateResource fetches metadata about the resource and produces the resultant manifest.
-func CreateResource(resource models.Resource, rootDir string, fs stuffbin.FileSystem) error {
+// CreateResource fetches metadata about the resource and produces the manifest.
+func CreateResource(resource models.Resource, rootDir string, workload string, fs stuffbin.FileSystem) error {
 	var (
 		template = resource.GetMetaData().TemplatePath
 		name     = resource.GetMetaData().Name
 		config   = resource.GetMetaData().Config
-		dest     = filepath.Join(rootDir, models.BaseDir, resource.GetMetaData().ManifestPath)
+		fName    = fmt.Sprintf("%s-%s.yml", resource.GetMetaData().Name, resource.GetMetaData().Type)
+		dest     = filepath.Join(rootDir, models.BaseDir, workload, fName)
 	)
 	return saveResource(template, name, dest, config, fs)
 }


### PR DESCRIPTION
This PR is a breaking change and is incompatible with the previous
`config.yml` structure. `config.yml` is now rewired to have a new parent
key `workloads` which accepts an array to represent different
applications. This structure is more UX friendly and visualises all the
resources required to run the app in a more modular way.

Closes https://github.com/mr-karan/kubekutr/issues/2