### PR TITLE
fix: set containerPort to targetPort if defined

### DIFF
--- a/templates/containers.tmpl
+++ b/templates/containers.tmpl
@@ -11,7 +11,7 @@
         {{- if .Ports}}
         ports:
         {{- range .Ports}}
-              - containerPort: {{- if .TargetPort }} {{.TargetPort}} {{- else }} {{.Port}} {{- end}}
+          - containerPort: {{- if .TargetPort }} {{.TargetPort}} {{- else }} {{.Port}} {{- end}}
           name: {{.Name}}
         {{- end}}
         {{- end}}

--- a/templates/containers.tmpl
+++ b/templates/containers.tmpl
@@ -11,7 +11,7 @@
         {{- if .Ports}}
         ports:
         {{- range .Ports}}
-        - containerPort: {{.Port}}
+              - containerPort: {{- if .TargetPort }} {{.TargetPort}} {{- else }} {{.Port}} {{- end}}
           name: {{.Name}}
         {{- end}}
         {{- end}}

--- a/templates/containers.tmpl
+++ b/templates/containers.tmpl
@@ -11,7 +11,7 @@
         {{- if .Ports}}
         ports:
         {{- range .Ports}}
-          - containerPort: {{- if .TargetPort }} {{.TargetPort}} {{- else }} {{.Port}} {{- end}}
+        - containerPort: {{- if .TargetPort }} {{.TargetPort}} {{- else }} {{.Port}} {{- end}}
           name: {{.Name}}
         {{- end}}
         {{- end}}


### PR DESCRIPTION
`containerPort` gets set to the template `port`, and `targetPort` is ignored even when defined. This causes an issue where `port` actually points to the external ClusterIP port, and the `targetPort` is the port where the service is exposed from the container. Hence, in the case where `targetPort` is defined, `containerPort` should be set to `targetPort` and not the external ClusterIP port.

eg: defining ports in kubekutr config like:
```yaml
ports:
  - port: 9000  # external cluster IP port
    targetPort: 8000  # actual internal container port
```
sets the containerPort to `9000` instead of `8000`, which is wrong in this case because `9000` is the port which is exposed to the cluster, and `8000` is the port that the container is supposed to expose.